### PR TITLE
Require DATABASE_URL configuration

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,10 +1,16 @@
 import { defineConfig } from 'drizzle-kit';
 
+const url = process.env.DATABASE_URL;
+
+if (!url) {
+  throw new Error('DATABASE_URL is not set');
+}
+
 export default defineConfig({
   dialect: 'postgresql',
   schema: './src/db/schema.ts',
   out: './drizzle',
   dbCredentials: {
-    url: process.env.DATABASE_URL!,
+    url,
   },
 });

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,6 +1,12 @@
 import postgres from 'postgres';
 import { drizzle } from 'drizzle-orm/postgres-js';
 
-const client = postgres(process.env.DATABASE_URL!);
+const connectionString = process.env.DATABASE_URL;
+
+if (!connectionString) {
+  throw new Error('DATABASE_URL is not set');
+}
+
+const client = postgres(connectionString);
 
 export const db = drizzle(client);


### PR DESCRIPTION
## Summary
- throw error if `DATABASE_URL` is missing when setting up the database client
- enforce `DATABASE_URL` presence in drizzle config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68afabb037d083309861c851125bd2d5