### PR TITLE
Require POSTGRES_URL configuration

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,10 +1,16 @@
 import { defineConfig } from 'drizzle-kit';
 
+const url = process.env.POSTGRES_URL;
+
+if (!url) {
+  throw new Error('POSTGRES_URL is not set');
+}
+
 export default defineConfig({
   dialect: 'postgresql',
   schema: './src/db/schema.ts',
   out: './drizzle',
   dbCredentials: {
-    url: process.env.DATABASE_URL!,
+    url,
   },
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,12 @@
-import { db } from "../db";
+import { getDb } from "../db";
 import { updates, users, userSettings } from "../db/schema";
 import { desc, eq, gt } from "drizzle-orm";
 import styles from "./page.module.css";
 
+export const dynamic = "force-dynamic";
+
 export default async function Dashboard() {
+  const db = getDb();
   const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
   const rows = await db
     .select({

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,6 +1,21 @@
 import postgres from 'postgres';
 import { drizzle } from 'drizzle-orm/postgres-js';
 
-const client = postgres(process.env.DATABASE_URL!);
+let db:
+  | ReturnType<typeof drizzle>
+  | undefined;
 
-export const db = drizzle(client);
+export function getDb() {
+  if (!db) {
+    const url = process.env.POSTGRES_URL;
+    if (!url) {
+      throw new Error('POSTGRES_URL is not set');
+    }
+
+    const client = postgres(url);
+    db = drizzle(client);
+  }
+
+  return db;
+}
+

--- a/template.env
+++ b/template.env
@@ -1,0 +1,5 @@
+# Example environment configuration
+# Copy to .env and fill in the values
+
+# PostgreSQL connection string
+POSTGRES_URL=


### PR DESCRIPTION
## Summary
- validate that `POSTGRES_URL` is present when initializing the Drizzle database client
- enforce the same requirement in Drizzle configuration to ensure CLI tasks use the intended database
- mark the dashboard page as dynamic and lazy-load the database client to avoid build-time queries
- document the required `POSTGRES_URL` in a `template.env` example file

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` fonts from Google)*


------
https://chatgpt.com/codex/tasks/task_b_68afabb037d083309861c851125bd2d5