### PR TITLE
Ensure database migrations run on startup

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import styles from "./page.module.css";
 export const dynamic = "force-dynamic";
 
 export default async function Dashboard() {
-  const db = getDb();
+  const db = await getDb();
   const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
   const rows = await db
     .select({

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,19 +1,19 @@
 import postgres from 'postgres';
 import { drizzle } from 'drizzle-orm/postgres-js';
+import { migrate } from 'drizzle-orm/postgres-js/migrator';
 
-let db:
-  | ReturnType<typeof drizzle>
-  | undefined;
+let db: ReturnType<typeof drizzle> | undefined;
 
-export function getDb() {
+export async function getDb() {
   if (!db) {
     const url = process.env.POSTGRES_URL;
     if (!url) {
       throw new Error('POSTGRES_URL is not set');
     }
 
-    const client = postgres(url);
+    const client = postgres(url, { max: 1 });
     db = drizzle(client);
+    await migrate(db, { migrationsFolder: './drizzle' });
   }
 
   return db;


### PR DESCRIPTION
## Summary
- run Drizzle migrations the first time the database is accessed
- await the database connection in the dashboard page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68afc15a5e708330b16e938521094f8c