### PR TITLE
Use absolute migration path for Drizzle

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,6 +1,7 @@
 import postgres from 'postgres';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import { migrate } from 'drizzle-orm/postgres-js/migrator';
+import { join } from 'path';
 
 let db: ReturnType<typeof drizzle> | undefined;
 
@@ -13,7 +14,7 @@ export async function getDb() {
 
     const client = postgres(url, { max: 1 });
     db = drizzle(client);
-    await migrate(db, { migrationsFolder: './drizzle' });
+    await migrate(db, { migrationsFolder: join(process.cwd(), 'drizzle') });
   }
 
   return db;


### PR DESCRIPTION
## Summary
- Resolve Drizzle migration folder using an absolute path so fresh databases can create tables reliably.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68afc32a87ec8330bc4c9ba18c10659f