### PR TITLE
Add selectable user dropdown

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -21,7 +21,12 @@
 .topBar {
   top: 0;
   border-bottom: 1px solid #eaeaea;
-  justify-content: flex-end;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.topBarButtons {
+  display: flex;
   gap: 8px;
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { getDb } from "../db";
 import { updates, users, userSettings } from "../db/schema";
 import { desc, eq, gt } from "drizzle-orm";
+import UserSelector, { type UserOption } from "../components/UserSelector";
 import styles from "./page.module.css";
 
 export const dynamic = "force-dynamic";
@@ -22,11 +23,18 @@ export default async function Dashboard() {
     .where(gt(updates.createdAt, since))
     .orderBy(desc(updates.createdAt));
 
+  const userOptions: UserOption[] = await db
+    .select({ id: users.id, displayName: users.displayName })
+    .from(users);
+
   return (
     <div className={styles.container}>
       <div className={styles.topBar}>
-        <button>Filters</button>
-        <button>Settings</button>
+        <UserSelector users={userOptions} />
+        <div className={styles.topBarButtons}>
+          <button>Filters</button>
+          <button>Settings</button>
+        </div>
       </div>
       <ul className={styles.updates}>
         {rows.map((row) => (

--- a/src/components/UserSelector.tsx
+++ b/src/components/UserSelector.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useLocalStorage } from "../hooks/useLocalStorage";
+
+export type UserOption = {
+  id: number;
+  displayName: string;
+};
+
+export default function UserSelector({ users }: { users: UserOption[] }) {
+  const [selectedUserId, setSelectedUserId] = useLocalStorage<string>(
+    "selectedUserId",
+    ""
+  );
+
+  return (
+    <select
+      value={selectedUserId}
+      onChange={(e) => setSelectedUserId(e.target.value)}
+    >
+      <option value="">Select user</option>
+      {users.map((user) => (
+        <option key={user.id} value={String(user.id)}>
+          {user.displayName}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useLocalStorage<T>(key: string, initialValue: T) {
+  const [value, setValue] = useState<T>(initialValue);
+
+  useEffect(() => {
+    try {
+      const item = window.localStorage.getItem(key);
+      if (item !== null) {
+        setValue(JSON.parse(item));
+      }
+    } catch {
+      // ignore read errors
+    }
+  }, [key]);
+
+  const setStoredValue = (newValue: T) => {
+    setValue(newValue);
+    try {
+      window.localStorage.setItem(key, JSON.stringify(newValue));
+    } catch {
+      // ignore write errors
+    }
+  };
+
+  return [value, setStoredValue] as const;
+}


### PR DESCRIPTION
## Summary
- add client-side hook for local storage state
- allow choosing a user from a dropdown stored in local storage
- adjust top bar layout for user selector and existing buttons

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68afdf4b24e083309341aa6d7eb0981c