### PR TITLE
Implement update posting and polling

### DIFF
--- a/src/app/UpdatesFeed.tsx
+++ b/src/app/UpdatesFeed.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import type { UpdateRecord } from '../db/queries';
+import styles from './page.module.css';
+
+interface Props {
+  initialUpdates: UpdateRecord[];
+}
+
+export default function UpdatesFeed({ initialUpdates }: Props) {
+  const [updates, setUpdates] = useState<UpdateRecord[]>(initialUpdates);
+  const [message, setMessage] = useState('');
+  const lastTime = useRef<Date>(
+    initialUpdates[0] ? new Date(initialUpdates[0].createdAt) : new Date(0),
+  );
+
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      const since = lastTime.current.toISOString();
+      const res = await fetch(`/api/updates?since=${encodeURIComponent(since)}`);
+      if (res.ok) {
+        const data: UpdateRecord[] = await res.json();
+        if (data.length > 0) {
+          lastTime.current = new Date(data[0].createdAt);
+          setUpdates((prev) => [...data, ...prev]);
+        }
+      }
+    }, 10000);
+    return () => clearInterval(interval);
+  }, []);
+
+  async function handlePost() {
+    const text = message.trim();
+    if (!text) return;
+    const res = await fetch('/api/updates', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: text, userId: 1 }),
+    });
+    if (res.ok) {
+      const row: UpdateRecord = await res.json();
+      lastTime.current = new Date(row.createdAt);
+      setUpdates((prev) => [row, ...prev]);
+      setMessage('');
+    }
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.topBar}>
+        <button>Filters</button>
+        <button>Settings</button>
+      </div>
+      <ul className={styles.updates}>
+        {updates.map((row) => (
+          <li key={row.id} className={styles.updateItem}>
+            <div className={styles.header}>
+              <span
+                className={styles.name}
+                style={{ color: row.color || 'inherit' }}
+              >
+                {row.displayName}
+              </span>
+              <span className={styles.time}>
+                {new Date(row.createdAt).toLocaleString()}
+              </span>
+            </div>
+            <p className={styles.message}>{row.message}</p>
+          </li>
+        ))}
+      </ul>
+      <div className={styles.bottomBar}>
+        <input
+          className={styles.input}
+          placeholder="Share an update..."
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+        />
+        <button className={styles.postButton} onClick={handlePost}>
+          Post
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/updates/route.ts
+++ b/src/app/api/updates/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { fetchUpdatesSince, insertUpdate } from '../../../db/queries';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const sinceParam = searchParams.get('since');
+  const since = sinceParam ? new Date(sinceParam) : new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const rows = await fetchUpdatesSince(since);
+  return NextResponse.json(rows);
+}
+
+export async function POST(request: Request) {
+  const { message, userId } = await request.json();
+  if (!message || !userId) {
+    return NextResponse.json(
+      { error: 'message and userId are required' },
+      { status: 400 },
+    );
+  }
+  const row = await insertUpdate(userId, message);
+  return NextResponse.json(row, { status: 201 });
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,55 +1,10 @@
-import { getDb } from "../db";
-import { updates, users, userSettings } from "../db/schema";
-import { desc, eq, gt } from "drizzle-orm";
-import styles from "./page.module.css";
+import UpdatesFeed from './UpdatesFeed';
+import { fetchUpdatesSince } from '../db/queries';
 
-export const dynamic = "force-dynamic";
+export const dynamic = 'force-dynamic';
 
 export default async function Dashboard() {
-  const db = await getDb();
   const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
-  const rows = await db
-    .select({
-      id: updates.id,
-      message: updates.message,
-      createdAt: updates.createdAt,
-      displayName: users.displayName,
-      color: userSettings.color,
-    })
-    .from(updates)
-    .innerJoin(users, eq(users.id, updates.userId))
-    .leftJoin(userSettings, eq(users.id, userSettings.userId))
-    .where(gt(updates.createdAt, since))
-    .orderBy(desc(updates.createdAt));
-
-  return (
-    <div className={styles.container}>
-      <div className={styles.topBar}>
-        <button>Filters</button>
-        <button>Settings</button>
-      </div>
-      <ul className={styles.updates}>
-        {rows.map((row) => (
-          <li key={row.id} className={styles.updateItem}>
-            <div className={styles.header}>
-              <span
-                className={styles.name}
-                style={{ color: row.color || "inherit" }}
-              >
-                {row.displayName}
-              </span>
-              <span className={styles.time}>
-                {row.createdAt.toLocaleString()}
-              </span>
-            </div>
-            <p className={styles.message}>{row.message}</p>
-          </li>
-        ))}
-      </ul>
-      <div className={styles.bottomBar}>
-        <input className={styles.input} placeholder="Share an update..." />
-        <button className={styles.postButton}>Post</button>
-      </div>
-    </div>
-  );
+  const rows = await fetchUpdatesSince(since);
+  return <UpdatesFeed initialUpdates={rows} />;
 }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1,0 +1,48 @@
+import { desc, eq, gt } from 'drizzle-orm';
+import { getDb } from './index';
+import { updates, users, userSettings } from './schema';
+
+export type UpdateRecord = {
+  id: number;
+  message: string;
+  createdAt: string;
+  displayName: string;
+  color: string | null;
+};
+
+const updateFields = {
+  id: updates.id,
+  message: updates.message,
+  createdAt: updates.createdAt,
+  displayName: users.displayName,
+  color: userSettings.color,
+};
+
+const baseQuery = (db: Awaited<ReturnType<typeof getDb>>) =>
+  db
+    .select(updateFields)
+    .from(updates)
+    .innerJoin(users, eq(users.id, updates.userId))
+    .leftJoin(userSettings, eq(users.id, userSettings.userId));
+
+export async function fetchUpdatesSince(since: Date): Promise<UpdateRecord[]> {
+  const db = await getDb();
+  const rows = await baseQuery(db)
+    .where(gt(updates.createdAt, since))
+    .orderBy(desc(updates.createdAt));
+  return rows.map((r) => ({ ...r, createdAt: r.createdAt.toISOString() }));
+}
+
+export async function insertUpdate(
+  userId: number,
+  message: string,
+): Promise<UpdateRecord> {
+  const db = await getDb();
+  const [inserted] = await db
+    .insert(updates)
+    .values({ userId, message })
+    .returning({ id: updates.id });
+
+  const [row] = await baseQuery(db).where(eq(updates.id, inserted.id));
+  return { ...row, createdAt: row.createdAt.toISOString() };
+}


### PR DESCRIPTION
## Summary
- Add database query helpers to fetch and insert updates
- Expose `/api/updates` route for creating and polling updates
- Move dashboard UI to new client component with send button and polling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68afdf8a1858833092bae09d1b7fa76a