### PR TITLE
feat: allow adjusting post font size

### DIFF
--- a/src/app/api/users/[userId]/settings/route.ts
+++ b/src/app/api/users/[userId]/settings/route.ts
@@ -18,8 +18,8 @@ export async function POST(
 ) {
   const { userId: userIdParam } = await context.params;
   const userId = Number(userIdParam);
-  const { displayName, color } = await request.json();
-  await updateUserSettings(userId, displayName, color);
+  const { displayName, color, fontSize } = await request.json();
+  await updateUserSettings(userId, displayName, color, Number(fontSize));
   return NextResponse.json({ ok: true });
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,7 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --post-font-size: 16px;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -71,6 +71,7 @@
 
 .message {
   margin-top: 4px;
+  font-size: var(--post-font-size);
 }
 
 .input {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import AdminButton from "@/components/AdminButton";
 import styles from "./page.module.css";
 import DashboardClient from "@/components/DashboardClient";
 import { SelectedUserProvider } from "@/state/SelectedUserContext";
+import { FontSizeProvider } from "@/state/FontSizeContext";
 
 export const dynamic = "force-dynamic";
 
@@ -20,17 +21,19 @@ export default async function Dashboard() {
 
   return (
     <SelectedUserProvider>
-      <div className={styles.container}>
-        <div className={styles.topBar}>
-          <UserSelector users={userOptions} />
-          <div className={styles.topBarButtons}>
-            <button>Filters</button>
-            <AdminButton />
-            <SettingsButton />
+      <FontSizeProvider>
+        <div className={styles.container}>
+          <div className={styles.topBar}>
+            <UserSelector users={userOptions} />
+            <div className={styles.topBarButtons}>
+              <button>Filters</button>
+              <AdminButton />
+              <SettingsButton />
+            </div>
           </div>
+          <DashboardClient users={userOptions} />
         </div>
-        <DashboardClient users={userOptions} />
-      </div>
+      </FontSizeProvider>
     </SelectedUserProvider>
   );
 }

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -5,6 +5,7 @@ import Modal from "./Modal";
 import styles from "./SettingsModal.module.css";
 import { useSelectedUser } from "@/state/SelectedUserContext";
 import { randomHexColor } from "@/utils/color";
+import { useFontSize } from "@/state/FontSizeContext";
 
 interface Props {
   userId: string;
@@ -15,6 +16,8 @@ interface Props {
 export default function SettingsModal({ userId, isOpen, onClose }: Props) {
   const [displayName, setDisplayName] = useState("");
   const [color, setColor] = useState("#000000");
+  const { fontSize: currentFontSize, setFontSize: setContextFontSize } = useFontSize();
+  const [fontSize, setFontSize] = useState<number>(currentFontSize);
   const { setSelectedUserId, selectedUserId } = useSelectedUser();
   const [hasPassword, setHasPassword] = useState<boolean>(false);
   const [newPassword, setNewPassword] = useState<string>("");
@@ -26,17 +29,23 @@ export default function SettingsModal({ userId, isOpen, onClose }: Props) {
       .then((data) => {
         if (data?.displayName) setDisplayName(data.displayName);
         if (data?.color) setColor(data.color);
+        if (typeof data?.fontSize === "number") setFontSize(data.fontSize);
         if (typeof data?.hasPassword === "boolean") setHasPassword(Boolean(data.hasPassword));
       });
   }, [isOpen, userId]);
+
+  useEffect(() => {
+    setFontSize(currentFontSize);
+  }, [currentFontSize]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     await fetch(`/api/users/${userId}/settings`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ displayName, color }),
+      body: JSON.stringify({ displayName, color, fontSize }),
     });
+    setContextFontSize(fontSize);
     onClose();
     window.location.reload();
   };
@@ -118,6 +127,17 @@ export default function SettingsModal({ userId, isOpen, onClose }: Props) {
               Randomize
             </button>
           </div>
+        </div>
+        <div className={styles.formGroup}>
+          <label htmlFor="fontSize">Font Size</label>
+          <input
+            id="fontSize"
+            type="number"
+            min={12}
+            max={32}
+            value={fontSize}
+            onChange={(e) => setFontSize(Number(e.target.value))}
+          />
         </div>
         <div className={styles.formGroup}>
           <label htmlFor="password">Password</label>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -12,6 +12,7 @@ export const userSettings = pgTable('user_settings', {
   id: serial('id').primaryKey(),
   userId: integer('user_id').references(() => users.id).notNull(),
   color: text('color').notNull(),
+  fontSize: integer('font_size').notNull().default(16),
 });
 
 export const updates = pgTable('updates', {

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -17,7 +17,11 @@ export async function seedDefaultUsers(
 
     if (inserted.length > 0) {
       await db.insert(userSettings).values(
-        inserted.map(({ id }) => ({ userId: id, color: randomHexColor() }))
+        inserted.map(({ id }) => ({
+          userId: id,
+          color: randomHexColor(),
+          fontSize: 16,
+        }))
       );
     }
   }

--- a/src/db/users.ts
+++ b/src/db/users.ts
@@ -13,7 +13,9 @@ export async function createUser(displayName: string) {
       .returning({ id: users.id });
 
     const color = randomHexColor();
-    await tx.insert(userSettings).values({ userId: inserted.id, color });
+    await tx
+      .insert(userSettings)
+      .values({ userId: inserted.id, color, fontSize: 16 });
 
     return inserted;
   });

--- a/src/state/FontSizeContext.tsx
+++ b/src/state/FontSizeContext.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { createContext, useContext, useEffect, useMemo } from "react";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
+
+interface FontSizeCtx {
+  fontSize: number;
+  setFontSize: (size: number) => void;
+}
+
+const FontSizeContext = createContext<FontSizeCtx | undefined>(undefined);
+
+export function FontSizeProvider({ children }: { children: React.ReactNode }) {
+  const [fontSize, setFontSize] = useLocalStorage<number>("fontSize", 16);
+
+  useEffect(() => {
+    document.documentElement.style.setProperty("--post-font-size", `${fontSize}px`);
+  }, [fontSize]);
+
+  const value = useMemo<FontSizeCtx>(() => ({ fontSize, setFontSize }), [fontSize, setFontSize]);
+
+  return <FontSizeContext.Provider value={value}>{children}</FontSizeContext.Provider>;
+}
+
+export function useFontSize() {
+  const ctx = useContext(FontSizeContext);
+  if (!ctx) throw new Error("useFontSize must be used within FontSizeProvider");
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- add persistent font size to user settings
- expose font size control in settings modal and apply across app

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68b07bddad18833088662d94f92f09b1