### PR TITLE
feat: poll for updates

### DIFF
--- a/src/hooks/usePolling.ts
+++ b/src/hooks/usePolling.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { useEffect, type DependencyList } from "react";
+
+// Repeatedly invoke a callback on a fixed interval.
+// Runs once immediately and again every `intervalMs` milliseconds.
+// Dependencies can be supplied to reset the interval when inputs change.
+export function usePolling(
+  callback: () => void,
+  intervalMs: number,
+  deps: DependencyList = []
+) {
+  useEffect(() => {
+    const id = window.setInterval(callback, intervalMs);
+    callback();
+    return () => window.clearInterval(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [callback, intervalMs, ...deps]);
+}


### PR DESCRIPTION
## Summary
- poll the updates feed on an interval
- add reusable polling hook for client components

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b224964e508330bae66e6ff6767ed9