### PR TITLE
fix: resolve migrations path

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,6 +1,7 @@
 import postgres from 'postgres';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import { migrate } from 'drizzle-orm/postgres-js/migrator';
+import path from 'path';
 import { seedDefaultUsers } from './seed';
 import { retry } from '../utils/retry';
 
@@ -8,13 +9,14 @@ let db: ReturnType<typeof drizzle> | undefined;
 
 const DB_RETRY_ATTEMPTS = 5;
 const DB_RETRY_DELAY_MS = 1000;
+const MIGRATIONS_FOLDER = path.join(process.cwd(), 'drizzle');
 
 async function connect(url: string) {
   // Prefer direct connection for migrations and disable prepared statements for pgbouncer compat
   const client = postgres(url, { max: 1, prepare: false });
   const connection = drizzle(client);
   // Run migrations once on first connect
-  await migrate(connection, { migrationsFolder: './drizzle' });
+  await migrate(connection, { migrationsFolder: MIGRATIONS_FOLDER });
   await seedDefaultUsers(connection);
   return connection;
 }


### PR DESCRIPTION
## Summary
- resolve drizzler migrations folder using process cwd to avoid missing meta/_journal.json

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68b2a0b38cd48330a604c31953d9c13a