### PR TITLE
Highlight key terms and user names with colors

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
 import { getDb } from "../db";
-import { users } from "../db/schema";
+import { users, userSettings } from "../db/schema";
 import { eq } from "drizzle-orm";
 import UserSelector, { type UserOption } from "../components/UserSelector";
 import SettingsButton from "../components/SettingsButton";
@@ -15,8 +15,9 @@ export default async function Dashboard() {
   const db = await getDb();
 
   const userOptions: UserOption[] = await db
-    .select({ id: users.id, displayName: users.displayName })
+    .select({ id: users.id, displayName: users.displayName, color: userSettings.color })
     .from(users)
+    .leftJoin(userSettings, eq(users.id, userSettings.userId))
     .where(eq(users.isActive, true));
 
   return (

--- a/src/components/DashboardClient.tsx
+++ b/src/components/DashboardClient.tsx
@@ -10,7 +10,7 @@ export default function DashboardClient({ users }: { users: UserOption[] }) {
 
   return (
     <>
-      <UpdatesFeed refreshToken={refreshToken} />
+      <UpdatesFeed refreshToken={refreshToken} users={users} />
       <PostBar users={users} onPosted={() => setRefreshToken((x) => x + 1)} />
     </>
   );

--- a/src/components/HighlightedText.module.css
+++ b/src/components/HighlightedText.module.css
@@ -1,4 +1,3 @@
 .highlight {
-  color: #0070f3;
   font-weight: bold;
 }

--- a/src/components/HighlightedText.tsx
+++ b/src/components/HighlightedText.tsx
@@ -1,4 +1,5 @@
 import styles from "./HighlightedText.module.css";
+import type { HighlightTerm } from "@/keyTerms";
 
 function escapeRegExp(str: string) {
   return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -9,24 +10,31 @@ export default function HighlightedText({
   terms,
 }: {
   text: string;
-  terms: string[];
+  terms: HighlightTerm[];
 }) {
   if (terms.length === 0) return text;
 
-  const regex = new RegExp(`(${terms.map(escapeRegExp).join("|")})`, "gi");
+  const regex = new RegExp(`(${terms.map((t) => escapeRegExp(t.term)).join("|")})`, "gi");
   const parts = text.split(regex);
 
   return (
     <>
-      {parts.map((part, i) =>
-        terms.some((term) => term.toLowerCase() === part.toLowerCase()) ? (
-          <span key={i} className={styles.highlight}>
+      {parts.map((part, i) => {
+        const match = terms.find(
+          (term) => term.term.toLowerCase() === part.toLowerCase()
+        );
+        return match ? (
+          <span
+            key={i}
+            className={styles.highlight}
+            style={{ color: match.color }}
+          >
             {part}
           </span>
         ) : (
           part
-        )
-      )}
+        );
+      })}
     </>
   );
 }

--- a/src/components/UpdatesFeed.tsx
+++ b/src/components/UpdatesFeed.tsx
@@ -7,7 +7,8 @@ import {
   type CSSProperties,
 } from "react";
 import HighlightedText from "./HighlightedText";
-import { KEY_TERMS } from "@/keyTerms";
+import { KEY_TERMS, type HighlightTerm } from "@/keyTerms";
+import type { UserOption } from "./UserSelector";
 import styles from "@/app/page.module.css";
 import { useSelectedUser } from "@/state/SelectedUserContext";
 import { useCssVar } from "@/hooks/useCssVar";
@@ -26,9 +27,11 @@ type UpdateRow = {
 export default function UpdatesFeed({
   refreshToken = 0,
   pollInterval = 30000,
+  users = [],
 }: {
   refreshToken?: number;
   pollInterval?: number;
+  users?: UserOption[];
 }) {
   const { selectedUserId } = useSelectedUser();
   const [rows, setRows] = useState<UpdateRow[]>([]);
@@ -50,6 +53,11 @@ export default function UpdatesFeed({
   }, [viewerId]);
 
   usePolling(fetchUpdates, pollInterval, [refreshToken]);
+
+  const terms = useMemo<HighlightTerm[]>(() => {
+    const userTerms = users.map((u) => ({ term: u.displayName, color: u.color }));
+    return [...KEY_TERMS, ...userTerms];
+  }, [users]);
 
   return (
     <ul className={styles.updates}>
@@ -110,7 +118,7 @@ export default function UpdatesFeed({
             })()}
           </div>
           <p className={styles.message}>
-            <HighlightedText text={row.message} terms={KEY_TERMS} />
+            <HighlightedText text={row.message} terms={terms} />
           </p>
         </li>
       ))}

--- a/src/components/UserSelector.tsx
+++ b/src/components/UserSelector.tsx
@@ -7,6 +7,7 @@ import CreateUserModal from "./CreateUserModal";
 export type UserOption = {
   id: number;
   displayName: string;
+  color: string;
 };
 
 const ADD_NEW_VALUE = "__add_new__";

--- a/src/keyTerms.ts
+++ b/src/keyTerms.ts
@@ -1,1 +1,10 @@
-export const KEY_TERMS = ["Haven", "Vivia", "Callum"];
+export type HighlightTerm = {
+  term: string;
+  color: string;
+};
+
+export const KEY_TERMS: HighlightTerm[] = [
+  { term: "Haven", color: "#ff69b4" },
+  { term: "Vivia", color: "#800080" },
+  { term: "Callum", color: "#0070f3" },
+];


### PR DESCRIPTION
## Summary
- represent key terms as objects with explicit colors (Haven pink, Vivia purple, Callum blue)
- highlight registered user names in updates using their configured colors

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b2a3a82cd88330ada56074d3ba1bbe