### PR TITLE
Handle nullable user colors

### DIFF
--- a/src/components/UpdatesFeed.tsx
+++ b/src/components/UpdatesFeed.tsx
@@ -55,7 +55,9 @@ export default function UpdatesFeed({
   usePolling(fetchUpdates, pollInterval, [refreshToken]);
 
   const terms = useMemo<HighlightTerm[]>(() => {
-    const userTerms = users.map((u) => ({ term: u.displayName, color: u.color }));
+    const userTerms = users.flatMap((u) =>
+      u.color ? [{ term: u.displayName, color: u.color }] : []
+    );
     return [...KEY_TERMS, ...userTerms];
   }, [users]);
 

--- a/src/components/UserSelector.tsx
+++ b/src/components/UserSelector.tsx
@@ -7,7 +7,7 @@ import CreateUserModal from "./CreateUserModal";
 export type UserOption = {
   id: number;
   displayName: string;
-  color: string;
+  color: string | null;
 };
 
 const ADD_NEW_VALUE = "__add_new__";


### PR DESCRIPTION
## Summary
- Allow `UserOption` color to be `null`
- Skip highlight terms for users without a color to keep type safety

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build` *(fails: Failed to fetch fonts from Google)*

------
https://chatgpt.com/codex/tasks/task_b_68b2a4e128c883309aab27c52d52418c