### PR TITLE
Randomize default color in settings picker

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 export default function SettingsModal({ userId, isOpen, onClose }: Props) {
   const [displayName, setDisplayName] = useState("");
-  const [color, setColor] = useState("#000000");
+  const [color, setColor] = useState(() => randomHexColor());
   const { fontSize: currentFontSize, setFontSize: setContextFontSize } = useFontSize();
   const [fontSize, setFontSize] = useState<number>(currentFontSize);
   const { setSelectedUserId, selectedUserId } = useSelectedUser();


### PR DESCRIPTION
## Summary
- Initialize SettingsModal color picker with a random color instead of black

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b2a735d7f48330aef8015685030313