### PR TITLE
Wrap option rows to fix mobile quick time picker overflow

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -117,6 +117,7 @@
   align-items: center;
   gap: 8px;
   margin-bottom: 8px;
+  flex-wrap: wrap;
 }
 
 .optionLabel {


### PR DESCRIPTION
## Summary
- Allow option rows to wrap so the quick time picker buttons stay within the options panel on narrow screens.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b36122cc0c83309d5917e52a4e351d