### PR TITLE
feat: expand highlight terms

### DIFF
--- a/src/components/UpdatesFeed.tsx
+++ b/src/components/UpdatesFeed.tsx
@@ -122,7 +122,7 @@ export default function UpdatesFeed({
 
   const terms = useMemo<HighlightTerm[]>(() => {
     const userTerms = users.flatMap((u) =>
-      u.color ? [{ term: u.displayName, color: u.color }] : []
+      u.color ? [{ terms: [u.displayName], color: u.color }] : []
     );
     return [...KEY_TERMS, ...userTerms];
   }, [users]);

--- a/src/keyTerms.ts
+++ b/src/keyTerms.ts
@@ -1,10 +1,19 @@
 export type HighlightTerm = {
-  term: string;
+  terms: string[];
   color: string;
 };
 
 export const KEY_TERMS: HighlightTerm[] = [
-  { term: "Haven", color: "#ff69b4" },
-  { term: "Vivia", color: "#800080" },
-  { term: "Callum", color: "#0070f3" },
+  {
+    terms: ["Haven", "Havey", "Hāve", "Havey baby boo boo Bear"],
+    color: "#ff69b4",
+  },
+  {
+    terms: ["Vivia", "Viv", "vivstar", "viv star"],
+    color: "#800080",
+  },
+  {
+    terms: ["Callum", "Cal", "little man", "he", "Callum Glen"],
+    color: "#0070f3",
+  },
 ];


### PR DESCRIPTION
## Summary
- support multiple aliases for highlighted names
- update highlight regex to respect word boundaries and case-insensitive matches
- include user-defined display names in new highlight term format

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b43d0dc604833091633bab52dcbe78